### PR TITLE
Remove Get/SetSampleRate(s) from the common interfaces.

### DIFF
--- a/dummy/device.go
+++ b/dummy/device.go
@@ -27,10 +27,7 @@ type dum struct {
 	samplers map[scope.ChanID]func(int) []scope.Sample
 }
 
-func (dum) String() string                     { return "dummy device" }
-func (dum) GetSampleRate() scope.SampleRate    { return 1000 }
-func (dum) GetSampleRates() []scope.SampleRate { return []scope.SampleRate{1000} }
-func (dum) SetSampleRate() error               { return nil }
+func (dum) String() string { return "dummy device" }
 
 func (d dum) Channels() []scope.ChanID {
 	return d.chanIDs

--- a/grab/grab.go
+++ b/grab/grab.go
@@ -29,7 +29,6 @@ import (
 var (
 	dev       = flag.String("device", "", "Device to use, autodetect if empty")
 	list      = flag.Bool("list", false, "If set, only list available devices")
-	rate      = flag.Int("rate", 1e6, "sampling rate (per second)")
 	voltRange = flag.Float64("range", 5.0, "sensitivity of the device (applied to all channels)")
 	chID      = flag.String("chan", "", "name of the channel to use. If not specified, use the first channel")
 	period    = flag.Duration("period", 0, "how long period of samples to collect, run forever if set to 0")
@@ -148,9 +147,7 @@ func main() {
 		log.Fatalf("ReadData: %+v", err)
 	}
 	defer stop()
-	rate := osc.GetSampleRate()
-	log.Printf("Sampling rate %s (interval %s)", rate, rate.Interval())
-	i := int(scope.DurationFromNano(*period) / rate.Interval())
+	i := int(scope.DurationFromNano(*period) / 1e6)
 	log.Printf("Reading %d samples", i)
 	for s := range data {
 		hist := &orderedHist{

--- a/scope/device.go
+++ b/scope/device.go
@@ -60,10 +60,4 @@ type Device interface {
 	// channel (as Data.Error). The channel may be closed by the device after
 	// encountering an error.
 	StartSampling() (data <-chan Data, stop func(), err error)
-
-	// GetSampleRate returns the currently configured sample rate.
-	GetSampleRate() SampleRate
-
-	// GetSampleRates returns a slice of sample rates available on this device.
-	GetSampleRates() []SampleRate
 }

--- a/usb/hantek6022be/init.go
+++ b/usb/hantek6022be/init.go
@@ -29,7 +29,7 @@ func New(d usbif.Device) (*Scope, error) {
 	for _, ch := range o.ch {
 		ch.SetVoltRange(5)
 	}
-	o.SetSampleRate(1e6)
+	o.setSampleRate(1e6)
 	if err := o.readCalibrationDataFromDevice(); err != nil {
 		return nil, errors.Wrap(err, "readCalibration")
 	}

--- a/usb/hantek6022be/scope.go
+++ b/usb/hantek6022be/scope.go
@@ -39,18 +39,8 @@ func (h *Scope) String() string {
 	return fmt.Sprintf("Hantek 6022BE Oscilloscope at USB bus 0x%x addr 0x%x", h.dev.Bus(), h.dev.Address())
 }
 
-// GetSampleRate returns the currently configured sample rate.
-func (h *Scope) GetSampleRate() scope.SampleRate {
-	return h.sampleRate
-}
-
-// GetSampleRates returns the list of supported sample rates.
-func (*Scope) GetSampleRates() []scope.SampleRate {
-	return sampleRates
-}
-
-// SetSampleRate sets the desired sample rate {
-func (h *Scope) SetSampleRate(s scope.SampleRate) error {
+// setSampleRate sets the desired sample rate {
+func (h *Scope) setSampleRate(s scope.SampleRate) error {
 	rate, ok := sampleRateToID[s]
 	if !ok {
 		return errors.Errorf("Sample rate %s is not supported by the device, need one of %v", s, sampleRates)


### PR DESCRIPTION
Sampling rates will later become device-specific params that will be opaque to the UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zagrodzki/goscope/23)
<!-- Reviewable:end -->
