### PR TITLE
Make Trigger part of the devices that use soft-triggers.

### DIFF
--- a/dummy/dummy.go
+++ b/dummy/dummy.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/zagrodzki/goscope/scope"
+	"github.com/zagrodzki/goscope/triggers"
 )
 
 const numSamples = 1000
@@ -59,5 +60,5 @@ func Open(ch string) (scope.Device, error) {
 		chs = append(chs, scope.ChanID(c))
 	}
 	d.chanIDs = chs
-	return d, nil
+	return triggers.New(d), nil
 }

--- a/gui/dummy_screen/main.go
+++ b/gui/dummy_screen/main.go
@@ -253,13 +253,17 @@ func main() {
 		wf.SetChannel(id, scope.TraceParams{Zero: 0.5, PerDiv: *perDiv})
 	}
 
-	tr := triggers.New(wf)
+	// Note: this is not useful long term, because it assumes that
+	// every device implements software triggers via triggers.Trigger.
+	// But it's good enough in the interim, before code is changed to use
+	// generic TriggerParams. See design doc for details.
+	tr := osc.(*triggers.Trigger)
 	tr.Source(scope.ChanID(*triggerSource))
 	tr.Edge(edge)
 	tr.Level(scope.Voltage(*triggerThresh))
 	tr.Mode(mode)
 
-	osc.Attach(tr)
+	osc.Attach(wf)
 	osc.Start()
 	defer osc.Stop()
 

--- a/triggers/edge.go
+++ b/triggers/edge.go
@@ -56,7 +56,10 @@ var autoDelay = 500 * scope.Millisecond
 // Trigger represents a filter running on the data channel, waiting for
 // a triggering event and then allowing a set of samples equal to the
 // configured timebase.
+// Trigger implements both scope.Device interface (used by UI)
+// and scope.DataRecorder interface (used by underlying device).
 type Trigger struct {
+	scope.Device
 	source   scope.ChanID
 	slope    RisingEdge
 	lvl      scope.Voltage
@@ -67,11 +70,17 @@ type Trigger struct {
 }
 
 // New returns an initialized Trigger.
-func New(rec scope.DataRecorder) *Trigger {
+func New(dev scope.Device) *Trigger {
 	return &Trigger{
-		rec:  rec,
-		mode: ModeAuto,
+		Device: dev,
+		mode:   ModeAuto,
 	}
+}
+
+// Attach configures the trigger to write filtered data to rec.
+func (t *Trigger) Attach(rec scope.DataRecorder) {
+	t.rec = rec
+	t.Device.Attach(t)
 }
 
 // TimeBase returns the trigger timebase, which is the same as the underlying recorder timebase.

--- a/triggers/edge_test.go
+++ b/triggers/edge_test.go
@@ -28,6 +28,14 @@ const (
 	missingSource = scope.ChanID("nonexistent")
 )
 
+type fakeDev struct{}
+
+func (fakeDev) String() string            { return "fake" }
+func (fakeDev) Channels() []scope.ChanID  { return nil }
+func (fakeDev) Attach(scope.DataRecorder) {}
+func (fakeDev) Start()                    {}
+func (fakeDev) Stop()                     {}
+
 func TestTrigger(t *testing.T) {
 	// set Auto mode to trigger after 8 samples without the condition.
 	defer func(d scope.Duration) { autoDelay = d }(autoDelay)
@@ -203,7 +211,8 @@ func TestTrigger(t *testing.T) {
 		},
 	} {
 		buf := testutil.NewBufferRecorder(scope.Duration(tc.tbLen) * scope.Millisecond)
-		tr := New(buf)
+		tr := New(&fakeDev{})
+		tr.Attach(buf)
 		tr.Source(tc.source)
 		tr.Level(tc.level)
 		tr.Edge(tc.edge)

--- a/usb/hantek6022be/init.go
+++ b/usb/hantek6022be/init.go
@@ -16,11 +16,12 @@ package hantek6022be
 
 import (
 	"github.com/pkg/errors"
+	"github.com/zagrodzki/goscope/triggers"
 	"github.com/zagrodzki/goscope/usb/usbif"
 )
 
 // New initializes oscilloscope through the passed USB device.
-func New(d usbif.Device) (*Scope, error) {
+func New(d usbif.Device) (*triggers.Trigger, error) {
 	o := &Scope{dev: d}
 	o.ch = [2]*ch{
 		{id: "CH1", osc: o},
@@ -33,7 +34,7 @@ func New(d usbif.Device) (*Scope, error) {
 	if err := o.readCalibrationDataFromDevice(); err != nil {
 		return nil, errors.Wrap(err, "readCalibration")
 	}
-	return o, nil
+	return triggers.New(o), nil
 }
 
 // Close releases the USB device.


### PR DESCRIPTION
The UI should not worry about the type of trigger that is provided. Triggers now are DataRecorders from the embedded Device's point of view and are Devices from the external DataRecorder's point of view.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zagrodzki/goscope/31)
<!-- Reviewable:end -->
