### PR TITLE
Support single channel

### DIFF
--- a/gui/dummy_screen/main.go
+++ b/gui/dummy_screen/main.go
@@ -121,7 +121,9 @@ func (w *waveform) Reset(inter scope.Duration, d <-chan []scope.ChannelData) {
 	go w.keepReading(d)
 }
 
-func (w *waveform) Error(error) {}
+func (w *waveform) Error(err error) {
+	log.Fatal(err)
+}
 
 func (w *waveform) SetTimeBase(d scope.Duration) {
 	w.tb = d

--- a/usb/hantek6022be/calibration.go
+++ b/usb/hantek6022be/calibration.go
@@ -15,8 +15,6 @@
 package hantek6022be
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 )
 
@@ -75,7 +73,6 @@ func (h *Scope) readCalibrationDataFromDevice() error {
 			},
 		},
 	}
-	fmt.Println("Calibration:", h.calibration)
 	return nil
 }
 

--- a/usb/hantek6022be/calibration.go
+++ b/usb/hantek6022be/calibration.go
@@ -45,7 +45,7 @@ func (h *Scope) readCalibrationDataFromDevice() error {
 		return errors.Wrap(err, "Control(read EEPROM) failed")
 	}
 	if n != len(data) {
-		return fmt.Errorf("Control(read EEPROM): want %d bytes, got %d", len(data), n)
+		return errors.Errorf("Control(read EEPROM): want %d bytes, got %d", len(data), n)
 	}
 	// alternating bytes for CH1 and CH2. First 16 bytes used for rates <=1Msps, second 16 bytes for >1Msps (<=48Msps)
 	// Of 8 bytes per channel, the values are for volt range 0.5, 0.5, 0.5, 1, 2.5, 5, 5, 5. Code uses only offsets 2..5.

--- a/usb/hantek6022be/capture.go
+++ b/usb/hantek6022be/capture.go
@@ -37,13 +37,16 @@ func (h *Scope) startCapture() error {
 	if recTB := h.rec.TimeBase(); tb > 8*recTB {
 		tb = 8 * recTB
 	}
-	readLen := (uint64(h.sampleRate) * numChan * uint64(tb)) / uint64(scope.Second)
-	// round up to nearest 512B
-	if readLen%512 != 0 {
-		readLen = 512 * (readLen/512 + 1)
-	}
-	if h.iso {
-		readLen = 3072 * 128
+	var readLen uint64
+	switch h.iso {
+	case true:
+		readLen = 3072 * 255
+	case false:
+		readLen = (uint64(h.sampleRate) * uint64(h.numChan) * uint64(tb)) / uint64(scope.Second)
+		// round up to nearest 512B
+		if readLen%512 != 0 {
+			readLen = 512 * (readLen/512 + 1)
+		}
 	}
 	sampleBuf = make([]byte, readLen)
 	return nil
@@ -72,26 +75,21 @@ func (h *Scope) getSamples(ep reader, p captureParams, ch chan<- []scope.Channel
 	if err != nil {
 		return errors.Wrap(err, "Read")
 	}
-	if num > len(sampleBuf) {
-		return errors.Errorf("USB buffer size too small: read %d bytes, buffer size %d", num, len(sampleBuf))
-	}
-	if num%numChan != 0 {
+	if num%int(h.numChan) != 0 {
 		return errors.Errorf("Read returned %d bytes of data, expected an even number for 2 channels", num)
 	}
-	samples := [2][]scope.Voltage{make([]scope.Voltage, num/numChan), make([]scope.Voltage, num/numChan)}
+	var samples [2][]scope.Voltage
+	for i := 0; i < h.numChan; i++ {
+		samples[i] = make([]scope.Voltage, num/h.numChan)
+	}
 	for i := 0; i < num; i++ {
-		samples[i%numChan][i/numChan] = scope.Voltage((float64(sampleBuf[i]) - p.calibration[i%numChan])) * p.scale[i%numChan]
+		samples[i%h.numChan][i/h.numChan] = scope.Voltage((float64(sampleBuf[i]) - p.calibration[i%h.numChan])) * p.scale[i%h.numChan]
 	}
 	ch <- []scope.ChannelData{
-		{
-			ID:      ch1ID,
-			Samples: samples[ch1Idx],
-		},
-		{
-			ID:      ch2ID,
-			Samples: samples[ch2Idx],
-		},
-	}
+		{ID: ch1ID, Samples: samples[ch1Idx]},
+		{ID: ch2ID, Samples: samples[ch2Idx]},
+	}[:h.numChan]
+
 	return nil
 }
 

--- a/usb/hantek6022be/channel.go
+++ b/usb/hantek6022be/channel.go
@@ -43,5 +43,5 @@ func (c *ch) setVoltRange(v rangeID) error {
 
 // Channels returns a list of channel names on the scope, names matching the channel labels on the device.
 func (h *Scope) Channels() []scope.ChanID {
-	return []scope.ChanID{ch1ID, ch2ID}
+	return []scope.ChanID{ch1ID, ch2ID}[:h.numChan]
 }

--- a/usb/hantek6022be/data.go
+++ b/usb/hantek6022be/data.go
@@ -55,11 +55,10 @@ const (
 	transferTypeMask  uint8 = 0x03
 	transferTypeIso   uint8 = 0x01
 
-	ch1ID   scope.ChanID = "CH1"
-	ch2ID   scope.ChanID = "CH2"
-	ch1Idx               = 0
-	ch2Idx               = 1
-	numChan              = 2
+	ch1ID  scope.ChanID = "CH1"
+	ch2ID  scope.ChanID = "CH2"
+	ch1Idx              = 0
+	ch2Idx              = 1
 )
 
 type rateID uint8

--- a/usb/hantek6022be/init.go
+++ b/usb/hantek6022be/init.go
@@ -65,7 +65,7 @@ See http://foo for details.`)
 	}
 	for _, ch := range o.ch {
 		if err := ch.setVoltRange(rangeID(*voltRange)); err != nil {
-			return nil, fmt.Errorf("setVoltRange(%s, %s): %v", ch.id, *voltRange, err)
+			return nil, fmt.Errorf("setVoltRange(%s, %d): %v", ch.id, *voltRange, err)
 		}
 	}
 	if o.iso {

--- a/usb/hantek6022be/init.go
+++ b/usb/hantek6022be/init.go
@@ -71,6 +71,7 @@ See http://foo for details.`)
 		o.setNumChan(2)
 	}
 	o.setSampleRate(SampleRate(*sampleRate * 1000))
+	// TODO(sebek): add reading calibration data from a file.
 	if err := o.readCalibrationDataFromDevice(); err != nil {
 		return nil, errors.Wrap(err, "readCalibration")
 	}

--- a/usb/hantek6022be/scope.go
+++ b/usb/hantek6022be/scope.go
@@ -34,6 +34,7 @@ type Scope struct {
 	calibration []calData
 	rec         scope.DataRecorder
 	iso         bool
+	numChan     int
 }
 
 // String returns a description of the device and it's USB address.
@@ -51,6 +52,15 @@ func (h *Scope) setSampleRate(s SampleRate) error {
 		return errors.Wrapf(err, "Control(sample rate %s(%x))", s, rate)
 	}
 	h.sampleRate = s
+	return nil
+}
+
+// setNumChan sets the number of active channels
+func (h *Scope) setNumChan(num int) error {
+	if _, err := h.dev.Control(controlTypeVendor, numChReq, 0, 0, []byte{byte(num)}); err != nil {
+		return errors.Wrapf(err, "Control(num channels %d)", num)
+	}
+	h.numChan = num
 	return nil
 }
 


### PR DESCRIPTION
With the custom firmware on the HT6022BE, it's possible to disable one channel, allocating more USB bandwidth for the first channel and achieving higher effective sample rate. Tests show successful 24msps with isochronous transfers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zagrodzki/goscope/36)
<!-- Reviewable:end -->
