### PR TITLE
Update goscope to use gousb version 2

### DIFF
--- a/usb/hantek6022be/data.go
+++ b/usb/hantek6022be/data.go
@@ -36,15 +36,15 @@ const (
 	eepromCalibrationOffset uint16 = 0x08
 	eepromCalibrationLen    int    = 0x20
 
-	bulkConfig    uint8 = 1
-	bulkInterface uint8 = 0
-	bulkAlt       uint8 = 0
-	bulkEP        uint8 = 0x86
+	bulkConfig    int = 1
+	bulkInterface int = 0
+	bulkAlt       int = 0
+	bulkEP        int = 6
 
-	isoConfig    uint8 = 1
-	isoInterface uint8 = 0
-	isoAlt       uint8 = 1
-	isoEP        uint8 = 0x82
+	isoConfig    int = 1
+	isoInterface int = 0
+	isoAlt       int = 1
+	isoEP        int = 2
 
 	// constants from libusb, defined by USB spec.
 	controlTypeMask   uint8 = 0x60

--- a/usb/usbif/usbif.go
+++ b/usb/usbif/usbif.go
@@ -14,34 +14,57 @@
 
 package usbif
 
-import usb "github.com/kylelemons/gousb/usb"
+import (
+	"github.com/google/gousb"
+	"github.com/pkg/errors"
+)
 
-// Device is an interface that mimics usb.Device, but can be replaced for testing
+// Device is an interface that mimics gousb.Device, but can be replaced for testing
 type Device interface {
 	Control(rType, request uint8, val, idx uint16, data []byte) (int, error)
-	OpenEndpoint(conf, iface, setup, epoint uint8) (usb.Endpoint, error)
+	OpenEndpoint(conf, iface, setup, epoint int) (*gousb.InEndpoint, error)
 	Close() error
-	Bus() uint8
-	Address() uint8
-	Configs() []usb.ConfigInfo
+	Bus() int
+	Address() int
+	Configs() map[int]gousb.ConfigDesc
 }
 
-// Desc is a convenience mapping to usb.Descriptor.
-type Desc usb.Descriptor
-
-// usbDev is a wrapper around *usb.Device implementing Device interface.
+// usbDev is a wrapper around *gousb.Device implementing Device interface.
 type usbDev struct {
-	*usb.Device
+	*gousb.Device
 }
 
 // Address returns USB device address.
-func (d usbDev) Address() uint8 { return d.Device.Address }
+func (d usbDev) Address() int { return d.Device.Desc.Address }
 
 // Bus returns USB device bus number.
-func (d usbDev) Bus() uint8 { return d.Device.Bus }
+func (d usbDev) Bus() int { return d.Device.Desc.Bus }
 
 // Configs returns a list of available USB device configs.
-func (d usbDev) Configs() []usb.ConfigInfo { return d.Device.Descriptor.Configs }
+func (d usbDev) Configs() map[int]gousb.ConfigDesc {
+	return d.Device.Desc.Configs
+}
 
-// FromRealDevice converts a usb.Device to Device.
-func FromRealDevice(d *usb.Device) Device { return usbDev{d} }
+// OpenEndpoint is a wrapper that sets the device config, claims the interface
+// and returns an InEndpoint ready for read.
+func (d usbDev) OpenEndpoint(conf, iface, setup, epoint int) (*gousb.InEndpoint, error) {
+	c, err := d.Config(conf)
+	if err != nil {
+		return nil, errors.Cause(err)
+	}
+	i, err := c.Interface(iface, setup)
+	if err != nil {
+		c.Close()
+		return nil, errors.Cause(err)
+	}
+	ep, err := i.InEndpoint(epoint)
+	if err != nil {
+		i.Close()
+		c.Close()
+		return nil, errors.Cause(err)
+	}
+	return ep, nil
+}
+
+// FromRealDevice converts a gousb.Device to Device.
+func FromRealDevice(d *gousb.Device) Device { return usbDev{d} }


### PR DESCRIPTION
...with relatively little effort - keep the OpenEndpoint signature, but update internals of usb.go to use the new library under the old signature. No functional changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zagrodzki/goscope/37)
<!-- Reviewable:end -->
