### PR TITLE
getSamples performance improvements

### DIFF
--- a/usb/hantek6022be/calibration.go
+++ b/usb/hantek6022be/calibration.go
@@ -20,7 +20,7 @@ import (
 
 type calData struct {
 	max  SampleRate
-	data map[rangeID][2]byte
+	data map[rangeID][maxChans]byte
 }
 
 func (h *Scope) readCalibrationDataFromDevice() error {
@@ -29,11 +29,11 @@ func (h *Scope) readCalibrationDataFromDevice() error {
 		h.calibration = []calData{
 			{
 				max: 48e6,
-				data: map[rangeID][2]byte{
-					voltRange0_5V: [2]byte{128, 128},
-					voltRange1V:   [2]byte{128, 128},
-					voltRange2_5V: [2]byte{128, 128},
-					voltRange5V:   [2]byte{128, 128},
+				data: map[rangeID][maxChans]byte{
+					voltRange0_5V: [maxChans]byte{128, 128},
+					voltRange1V:   [maxChans]byte{128, 128},
+					voltRange2_5V: [maxChans]byte{128, 128},
+					voltRange5V:   [maxChans]byte{128, 128},
 				},
 			},
 		}
@@ -52,23 +52,23 @@ func (h *Scope) readCalibrationDataFromDevice() error {
 	h.calibration = []calData{
 		{
 			max: 48e6,
-			data: map[rangeID][2]byte{
+			data: map[rangeID][maxChans]byte{
 				// data[16..19] are copies of data[20..21]
-				voltRange0_5V: [2]byte{data[20], data[21]},
-				voltRange1V:   [2]byte{data[22], data[23]},
-				voltRange2_5V: [2]byte{data[24], data[25]},
-				voltRange5V:   [2]byte{data[26], data[27]},
+				voltRange0_5V: [maxChans]byte{data[20], data[21]},
+				voltRange1V:   [maxChans]byte{data[22], data[23]},
+				voltRange2_5V: [maxChans]byte{data[24], data[25]},
+				voltRange5V:   [maxChans]byte{data[26], data[27]},
 				// data[28..31] are copies of data[26..27]
 			},
 		},
 		{
 			max: 1e6,
-			data: map[rangeID][2]byte{
+			data: map[rangeID][maxChans]byte{
 				// data[0..3] are copies of data[4..5]
-				voltRange0_5V: [2]byte{data[4], data[5]},
-				voltRange1V:   [2]byte{data[6], data[7]},
-				voltRange2_5V: [2]byte{data[8], data[9]},
-				voltRange5V:   [2]byte{data[10], data[11]},
+				voltRange0_5V: [maxChans]byte{data[4], data[5]},
+				voltRange1V:   [maxChans]byte{data[6], data[7]},
+				voltRange2_5V: [maxChans]byte{data[8], data[9]},
+				voltRange5V:   [maxChans]byte{data[10], data[11]},
 				// data[12..15] are copies of data[10..11]
 			},
 		},
@@ -77,8 +77,8 @@ func (h *Scope) readCalibrationDataFromDevice() error {
 }
 
 // getCalibration returns values to subtract from samples for each channel, based on current sample rate and measurement ranges.
-func (h *Scope) getCalibrationData() [2]float64 {
-	var calibration [2]float64
+func (h *Scope) getCalibrationData() [maxChans]float64 {
+	var calibration [maxChans]float64
 	for _, c := range h.calibration {
 		if h.sampleRate <= c.max {
 			calibration[ch1Idx] = float64(c.data[h.ch[ch1Idx].voltRange][ch1Idx])

--- a/usb/hantek6022be/capture.go
+++ b/usb/hantek6022be/capture.go
@@ -83,7 +83,7 @@ func (h *Scope) getSamples(ep reader, p *captureParams, ch chan<- []scope.Channe
 	for ch := 0; ch < h.numChan; ch++ {
 		s := make([]scope.Voltage, num/h.numChan)
 		trans := p.translateSample[ch]
-		for in, out := ch, 0; in < num; in, out = in+2, out+1 {
+		for in, out := ch, 0; in < num; in, out = in+h.numChan, out+1 {
 			s[out] = trans[sampleBuf[in]]
 		}
 		samples[ch] = s

--- a/usb/hantek6022be/capture.go
+++ b/usb/hantek6022be/capture.go
@@ -80,11 +80,13 @@ func (h *Scope) getSamples(ep reader, p *captureParams, ch chan<- []scope.Channe
 		return errors.Errorf("Read returned %d bytes of data, expected a number divisible by %d for %d channels", num, h.numChan, h.numChan)
 	}
 	var samples [2][]scope.Voltage
-	for i := 0; i < h.numChan; i++ {
-		samples[i] = make([]scope.Voltage, num/h.numChan)
-	}
-	for i := 0; i < num; i++ {
-		samples[i%h.numChan][i/h.numChan] = p.translateSample[i%h.numChan][sampleBuf[i]]
+	for ch := 0; ch < h.numChan; ch++ {
+		s := make([]scope.Voltage, num/h.numChan)
+		trans := p.translateSample[ch]
+		for in, out := ch, 0; in < num; in, out = in+2, out+1 {
+			s[out] = trans[sampleBuf[in]]
+		}
+		samples[ch] = s
 	}
 	ch <- []scope.ChannelData{
 		{ID: ch1ID, Samples: samples[ch1Idx]},

--- a/usb/hantek6022be/capture_test.go
+++ b/usb/hantek6022be/capture_test.go
@@ -1,3 +1,17 @@
+//  Copyright 2017 The goscope Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package hantek6022be
 
 import (

--- a/usb/hantek6022be/capture_test.go
+++ b/usb/hantek6022be/capture_test.go
@@ -70,12 +70,13 @@ func getSamplesFastLookupOne(buf []byte) [][]scope.Voltage {
 	for ch := range samples {
 		samples[ch] = make([]scope.Voltage, num/numChan)
 	}
-	ch := 0
+	ch, dst := 0, 0
 	for i := 0; i < num; i++ {
-		samples[ch][i/numChan] = voltLookup[ch][buf[i]]
+		samples[ch][dst] = voltLookup[ch][buf[i]]
 		ch++
 		if ch >= numChan {
 			ch = 0
+			dst++
 		}
 	}
 	return samples

--- a/usb/hantek6022be/capture_test.go
+++ b/usb/hantek6022be/capture_test.go
@@ -1,0 +1,117 @@
+package hantek6022be
+
+import (
+	"testing"
+
+	"github.com/zagrodzki/goscope/scope"
+)
+
+var (
+	calibration = []float64{128, 128}
+	scale       = []scope.Voltage{0.04, 0.04}
+	numChan     = 2
+)
+
+func getSamplesSingleMake(buf []byte) [][]scope.Voltage {
+	num := len(buf)
+	samples := make([]scope.Voltage, num)
+	step := num / numChan
+	for ch := 0; ch < numChan; ch++ {
+		for src, dst := ch, ch*step; src < num; src, dst = src+numChan, dst+1 {
+			samples[dst] = 99
+		}
+	}
+	return [][]scope.Voltage{samples[:step], samples[step:]}
+}
+
+func getSamplesTwoMakes(buf []byte) [][]scope.Voltage {
+	num := len(buf)
+	samples := [][]scope.Voltage{
+		make([]scope.Voltage, num/numChan),
+		make([]scope.Voltage, num/numChan),
+	}
+	for ch := 0; ch < numChan; ch++ {
+		for src, dst := ch, 0; src < num; src, dst = src+numChan, dst+1 {
+			samples[ch][dst] = 99
+		}
+	}
+	return samples
+}
+
+var voltLookup [][]scope.Voltage
+
+func init() {
+	voltLookup = make([][]scope.Voltage, numChan)
+	for ch := range voltLookup {
+		voltLookup[ch] = make([]scope.Voltage, 256)
+		for i := 0; i < 256; i++ {
+			voltLookup[ch][i] = scope.Voltage(float64(i)-calibration[ch]) * scale[ch]
+		}
+	}
+}
+
+func getSamplesFastLookupTwo(buf []byte) [][]scope.Voltage {
+	num := len(buf)
+	samples := make([][]scope.Voltage, numChan)
+	for ch := 0; ch < numChan; ch++ {
+		samples[ch] = make([]scope.Voltage, num/numChan)
+		base := voltLookup[ch]
+		out := samples[ch]
+		for dst, src := 0, ch; src < num; dst, src = dst+1, src+numChan {
+			out[dst] = base[buf[src]]
+		}
+	}
+	return samples
+}
+
+func getSamplesFastLookupOne(buf []byte) [][]scope.Voltage {
+	num := len(buf)
+	samples := make([][]scope.Voltage, numChan)
+	for ch := range samples {
+		samples[ch] = make([]scope.Voltage, num/numChan)
+	}
+	ch := 0
+	for i := 0; i < num; i++ {
+		samples[ch][i/numChan] = voltLookup[ch][buf[i]]
+		ch++
+		if ch >= numChan {
+			ch = 0
+		}
+	}
+	return samples
+}
+
+func BenchmarkGetSamples(b *testing.B) {
+	buf := make([]byte, 20000)
+	for i := range buf {
+		buf[i] = 100 + byte(i%60)
+	}
+	var out [][]scope.Voltage
+	for _, tc := range []struct {
+		name string
+		f    func([]byte) [][]scope.Voltage
+	}{
+		{
+			name: "single make",
+			f:    getSamplesSingleMake,
+		},
+		{
+			name: "two makes",
+			f:    getSamplesTwoMakes,
+		},
+		{
+			name: "fast lookup one loop",
+			f:    getSamplesFastLookupOne,
+		},
+		{
+			name: "fast lookup two loops",
+			f:    getSamplesFastLookupTwo,
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				out = tc.f(buf)
+			}
+		})
+	}
+}

--- a/usb/hantek6022be/data.go
+++ b/usb/hantek6022be/data.go
@@ -55,10 +55,11 @@ const (
 	transferTypeMask  uint8 = 0x03
 	transferTypeIso   uint8 = 0x01
 
-	ch1ID  scope.ChanID = "CH1"
-	ch2ID  scope.ChanID = "CH2"
-	ch1Idx              = 0
-	ch2Idx              = 1
+	ch1ID    scope.ChanID = "CH1"
+	ch2ID    scope.ChanID = "CH2"
+	ch1Idx                = 0
+	ch2Idx                = 1
+	maxChans              = 2
 )
 
 type rateID uint8


### PR DESCRIPTION
Benchmark results:
BenchmarkGetSamples/single_make-4         	   50000	     28906 ns/op
BenchmarkGetSamples/two_makes-4           	   50000	     37339 ns/op
BenchmarkGetSamples/fast_lookup_one_loop-4         	   30000	     50444 ns/op
BenchmarkGetSamples/fast_lookup_two_loops-4        	   50000	     35126 ns/op

PProf results from running a 10 second capture:
before: https://pastebin.com/vv8YBLiT
after: https://pastebin.com/JvxEmdJm

Time spent in getSamples for this run dropped from 17% of the runtime to <5% of the runtime.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zagrodzki/goscope/40)
<!-- Reviewable:end -->
