### PR TITLE
More flexibility in USB transfer configuration.

### DIFF
--- a/usb/hantek6022be/calibration.go
+++ b/usb/hantek6022be/calibration.go
@@ -24,7 +24,7 @@ type calData struct {
 }
 
 func (h *Scope) readCalibrationDataFromDevice() error {
-	if h.iso {
+	if h.customFW {
 		// Custom firmware doesn't support eeprom access at this point. Use static data for now.
 		h.calibration = []calData{
 			{

--- a/usb/hantek6022be/capture.go
+++ b/usb/hantek6022be/capture.go
@@ -87,7 +87,7 @@ func (h *Scope) Start() {
 	usbIf := bulkInterface
 	usbAlt := bulkAlt
 	usbEP := bulkEP
-	if h.iso {
+	if h.customFW && !h.forceBulk {
 		usbCfg = isoConfig
 		usbIf = isoInterface
 		usbAlt = isoAlt


### PR DESCRIPTION
Rename Scope.iso to Scope.customFW - it reflects whether the deviceuses the iso-capable firmware, not whether it actually uses iso transfers.

Add a "--force_bulk" command line flag to force the use of bulk
transfers even on the iso-capable firmware.

Add the missing 12M sampling rate for the custom firmware.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zagrodzki/goscope/42)
<!-- Reviewable:end -->
