### PR TITLE
Use a background image for each frame of drawn waveform 

### DIFF
--- a/gui/drawover.go
+++ b/gui/drawover.go
@@ -1,0 +1,37 @@
+//  Copyright 2017 The goscope Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package gui
+
+import "image"
+
+// The lower the alpha channel value, the less visible the pixel should be in
+// the resulting blend. We arbitrarily define Alpha of 10 to mean
+// "almost invisible" and don't copy these pixels anymore.
+const alphaInvisibilityThreshold = 10
+
+// DrawOver copies opaque pixels of src onto dst into the same positions,
+// effectively drawing over the dst. dst and src must be of the same size.
+// DrawOver handles the alpha channel only in the most simplified way.
+// For complex drawing operations, use image/draw package instead.
+func DrawOver(dst *image.RGBA, src *image.RGBA) {
+	// every pixel is represented by four consecutive bytes in Pix:
+	// red, green, blue, alpha.
+	for i := 0; i < len(dst.Pix); i += 4 {
+		if src.Pix[i+3] < alphaInvisibilityThreshold {
+			continue
+		}
+		copy(dst.Pix[i:i+4], src.Pix[i:i+4])
+	}
+}

--- a/gui/drawover.go
+++ b/gui/drawover.go
@@ -22,10 +22,14 @@ import "image"
 const alphaInvisibilityThreshold = 10
 
 // DrawOver copies opaque pixels of src onto dst into the same positions,
-// effectively drawing over the dst. dst and src must be of the same size.
+// effectively drawing over the dst. DrawOver panics if dst and src are
+// not of the same dimensions.
 // DrawOver handles the alpha channel only in the most simplified way.
 // For complex drawing operations, use image/draw package instead.
 func DrawOver(dst *image.RGBA, src *image.RGBA) {
+	if dst.Rect != src.Rect {
+		panic("DrawOver: dst and src have different bounds.")
+	}
 	// every pixel is represented by four consecutive bytes in Pix:
 	// red, green, blue, alpha.
 	for i := 0; i < len(dst.Pix); i += 4 {

--- a/gui/drawover_test.go
+++ b/gui/drawover_test.go
@@ -1,3 +1,17 @@
+//  Copyright 2017 The goscope Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package gui
 
 import (

--- a/gui/drawover_test.go
+++ b/gui/drawover_test.go
@@ -1,0 +1,71 @@
+package gui
+
+import (
+	"image"
+	"image/draw"
+	"testing"
+)
+
+func bgAndPlot() (*image.RGBA, *image.RGBA) {
+	size := image.Point{800, 600}
+	bg := NewPlot(size)
+	bg.Fill(ColorWhite)
+	plot := NewPlot(size)
+	plot.DrawLine(image.Point{0, 0}, size, plot.Bounds(), ColorBlack)
+	plot.DrawLine(image.Point{0, size.Y}, image.Point{size.X, 0}, plot.Bounds(), ColorRed)
+	plot.DrawLine(image.Point{0, size.Y / 2}, image.Point{size.X, size.Y / 2}, plot.Bounds(), ColorGreen)
+	plot.DrawLine(image.Point{size.X / 2, 0}, image.Point{size.X / 2, size.Y}, plot.Bounds(), ColorBlue)
+	return bg.RGBA, plot.RGBA
+}
+
+func TestDrawOver(t *testing.T) {
+	// Assuming that image/draw.Draw is the canonical implementation and
+	// is always correct.
+	bg, plot := bgAndPlot()
+	if plot.Opaque() {
+		t.Fatal("plot is completely opaque, expected partial translucent")
+	}
+	want := image.NewRGBA(bg.Bounds())
+	draw.Draw(want, want.Bounds(), bg, image.Point{0, 0}, draw.Over)
+	draw.Draw(want, want.Bounds(), plot, image.Point{0, 0}, draw.Over)
+	got := image.NewRGBA(bg.Bounds())
+	DrawOver(got, bg)
+	DrawOver(got, plot)
+	for i := 0; i < len(got.Pix); i += 4 {
+		for j := i; j < i+4; j++ {
+			if got.Pix[j] != want.Pix[j] {
+				t.Fatalf("pixel %d: got %v, want %v", i, got.Pix[i:i+3], want.Pix[i:i+3])
+			}
+		}
+	}
+}
+
+func BenchmarkDrawOver(b *testing.B) {
+	bg, plot := bgAndPlot()
+	b.Run("draw package dense", func(b *testing.B) {
+		out := image.NewRGBA(bg.Bounds())
+		for i := 0; i < b.N; i++ {
+			draw.Draw(out, out.Bounds(), bg, image.Point{0, 0}, draw.Over)
+			draw.Draw(out, out.Bounds(), plot, image.Point{0, 0}, draw.Over)
+		}
+	})
+	b.Run("simplified dense", func(b *testing.B) {
+		out := image.NewRGBA(bg.Bounds())
+		for i := 0; i < b.N; i++ {
+			DrawOver(out, bg)
+			DrawOver(out, plot)
+		}
+	})
+	b.Run("draw package sparse", func(b *testing.B) {
+		out := image.NewRGBA(bg.Bounds())
+		for i := 0; i < b.N; i++ {
+			draw.Draw(out, out.Bounds(), plot, image.Point{0, 0}, draw.Over)
+		}
+	})
+	b.Run("simplified sparse", func(b *testing.B) {
+		out := image.NewRGBA(bg.Bounds())
+		for i := 0; i < b.N; i++ {
+			DrawOver(out, plot)
+		}
+	})
+}

--- a/gui/dummy_screen/main.go
+++ b/gui/dummy_screen/main.go
@@ -170,8 +170,12 @@ var (
 func newWaveform(screenSize image.Point) *waveform {
 	p := gui.NewPlot(screenSize)
 	p.Fill(gui.ColorWhite)
-	p.DrawLine(image.Point{0, 0}, screenSize, p.Bounds(), gui.ColorBlack)
-	p.DrawLine(image.Point{0, screenSize.Y}, image.Point{screenSize.X, 0}, p.Bounds(), gui.ColorBlack)
+	for i := 1; i < gui.DivRows; i++ {
+		p.DrawLine(image.Point{0, i * screenSize.Y / gui.DivRows}, image.Point{screenSize.X, i * screenSize.Y / gui.DivRows}, p.Bounds(), gui.ColorGrey)
+	}
+	for i := 1; i < gui.DivCols; i++ {
+		p.DrawLine(image.Point{i * screenSize.X / gui.DivCols, 0}, image.Point{i * screenSize.X / gui.DivCols, screenSize.Y}, p.Bounds(), gui.ColorGrey)
+	}
 	ret := &waveform{
 		bgImage: p.RGBA,
 		plot:    gui.NewPlot(screenSize),

--- a/gui/dummy_screen/main.go
+++ b/gui/dummy_screen/main.go
@@ -70,11 +70,11 @@ func (w *waveform) TimeBase() scope.Duration {
 }
 
 var allColors = []color.RGBA{
-	color.RGBA{255, 0, 0, 255},
-	color.RGBA{0, 200, 0, 255},
-	color.RGBA{0, 0, 255, 255},
-	color.RGBA{255, 0, 255, 255},
-	color.RGBA{255, 255, 0, 255},
+	gui.ColorRed,
+	gui.ColorGreen,
+	gui.ColorBlue,
+	gui.ColorPurple,
+	gui.ColorYellow,
 }
 
 func (w *waveform) swapPlot() {
@@ -169,9 +169,9 @@ var (
 
 func newWaveform(screenSize image.Point) *waveform {
 	p := gui.NewPlot(screenSize)
-	p.Fill(color.RGBA{255, 255, 255, 255})
-	p.DrawLine(image.Point{0, 0}, screenSize, p.Bounds(), color.RGBA{0, 0, 0, 255})
-	p.DrawLine(image.Point{0, screenSize.Y}, image.Point{screenSize.X, 0}, p.Bounds(), color.RGBA{0, 0, 0, 255})
+	p.Fill(gui.ColorWhite)
+	p.DrawLine(image.Point{0, 0}, screenSize, p.Bounds(), gui.ColorBlack)
+	p.DrawLine(image.Point{0, screenSize.Y}, image.Point{screenSize.X, 0}, p.Bounds(), gui.ColorBlack)
 	ret := &waveform{
 		bgImage: p.RGBA,
 		plot:    gui.NewPlot(screenSize),

--- a/gui/dummy_screen/main.go
+++ b/gui/dummy_screen/main.go
@@ -177,6 +177,8 @@ func newWaveform(screenSize image.Point) *waveform {
 		plot:    gui.NewPlot(screenSize),
 		bufPlot: gui.NewPlot(screenSize),
 	}
+	copy(ret.plot.Pix, p.RGBA.Pix)
+	copy(ret.bufPlot.Pix, p.RGBA.Pix)
 	return ret
 }
 

--- a/gui/dummy_screen/main.go
+++ b/gui/dummy_screen/main.go
@@ -46,8 +46,8 @@ var (
 	triggerEdge      = flag.String("trigger_edge", "rising", "Trigger edge, rising or falling")
 	triggerMode      = flag.String("trigger_mode", "none", "Trigger mode. Use \"help\" to see the list of available modes.")
 	useChan          = flag.String("channel", "sin", "one of the channels of dummy device: zero,random,sin,triangle,square")
-	timeBase         = flag.Duration("timebase", time.Second, "timebase of the displayed waveform")
-	perDiv           = flag.Float64("v_per_div", 2, "volts per div")
+	timePerDiv       = flag.Duration("time_per_div", time.Millisecond, "time duration of one div on X axis")
+	voltsPerDiv      = flag.Float64("volts_per_div", 2, "difference in volts across one div on Y axis")
 	screenWidth      = flag.Int("width", 800, "UI width, in pixels")
 	screenHeight     = flag.Int("height", 600, "UI height, in pixels")
 	refreshRateLimit = flag.Float64("refresh_rate", 25, "maximum refresh rate, in frames per second. 0 = no limit")
@@ -241,10 +241,10 @@ func main() {
 	}
 	screenSize := image.Point{*screenWidth, *screenHeight}
 	wf := newWaveform(screenSize)
-	wf.SetTimeBase(scope.DurationFromNano(*timeBase))
+	wf.SetTimeBase(scope.DurationFromNano(*timePerDiv * gui.DivCols))
 
 	for _, id := range osc.Channels() {
-		wf.SetChannel(id, scope.TraceParams{Zero: 0.5, PerDiv: *perDiv})
+		wf.SetChannel(id, scope.TraceParams{Zero: 0.5, PerDiv: *voltsPerDiv})
 	}
 
 	// Note: this is not useful long term, because it assumes that

--- a/gui/dummy_screen/main.go
+++ b/gui/dummy_screen/main.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"image"
 	"image/color"
-	"image/draw"
 	"log"
 	"os"
 	"runtime/pprof"
@@ -142,7 +141,7 @@ func (w *waveform) SetChannel(ch scope.ChanID, p scope.TraceParams) {
 func (w *waveform) Render(ret *image.RGBA) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	draw.Draw(ret, ret.Bounds(), w.plot.RGBA, image.Point{0, 0}, draw.Over)
+	gui.DrawOver(ret, w.plot.RGBA)
 }
 
 type system struct {

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -33,8 +33,15 @@ const (
 	defaultVoltsPerDiv = 0.5
 )
 
-var colorWhite = color.RGBA{255, 255, 255, 255}
-var colorBlack = color.RGBA{0, 0, 0, 255}
+var (
+	ColorWhite  = color.RGBA{255, 255, 255, 255}
+	ColorBlack  = color.RGBA{0, 0, 0, 255}
+	ColorRed    = color.RGBA{255, 0, 0, 255}
+	ColorGreen  = color.RGBA{0, 200, 0, 255}
+	ColorBlue   = color.RGBA{0, 0, 255, 255}
+	ColorPurple = color.RGBA{255, 0, 255, 255}
+	ColorYellow = color.RGBA{255, 255, 0, 255}
+)
 
 var interpType = flag.String("interpolation", "sinczeropad", "interpolation type: one of linear, step, sinc, sinczeropad")
 
@@ -222,7 +229,7 @@ func (plot Plot) DrawAll(data []scope.ChannelData, traceParams map[scope.ChanID]
 		}
 		col, exists := cols[id]
 		if !exists {
-			col = colorBlack
+			col = ColorBlack
 		}
 		if err := plot.DrawSamples(v, params, b, col); err != nil {
 			return err

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -27,12 +27,17 @@ import (
 )
 
 const (
-	DivRows            = 8
+	// DivRows specifies the number of horizontal rows, where each row spans an
+	// identical distance expressed in volts.
+	DivRows = 8
+	// DivCols specifies of vertical columns, where each column spans an
+	// idential duration of time.
 	DivCols            = 10
 	defaultZero        = 0.5
 	defaultVoltsPerDiv = 0.5
 )
 
+// Commonly used color values.
 var (
 	ColorWhite  = color.RGBA{255, 255, 255, 255}
 	ColorBlack  = color.RGBA{0, 0, 0, 255}

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -213,7 +213,6 @@ func (plot Plot) DrawSamples(samples []scope.Voltage, traceParams scope.TracePar
 
 // DrawAll draws samples from all the channels in the plot.
 func (plot Plot) DrawAll(data []scope.ChannelData, traceParams map[scope.ChanID]scope.TraceParams, cols map[scope.ChanID]color.RGBA) error {
-	plot.Fill(colorWhite)
 	b := plot.Bounds()
 	for _, chanData := range data {
 		id, v := chanData.ID, chanData.Samples

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -41,6 +41,7 @@ var (
 	ColorBlue   = color.RGBA{0, 0, 255, 255}
 	ColorPurple = color.RGBA{255, 0, 255, 255}
 	ColorYellow = color.RGBA{255, 255, 0, 255}
+	ColorGrey   = color.RGBA{200, 200, 200, 255}
 )
 
 var interpType = flag.String("interpolation", "sinczeropad", "interpolation type: one of linear, step, sinc, sinczeropad")

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	divRows            = 8
-	divCols            = 10
+	DivRows            = 8
+	DivCols            = 10
 	defaultZero        = 0.5
 	defaultVoltsPerDiv = 0.5
 )
@@ -72,8 +72,8 @@ func samplesToPoints(samples []scope.Voltage, traceParams scope.TraceParams, rec
 		return nil
 	}
 
-	sampleMaxY := (1 - traceParams.Zero) * divRows * traceParams.PerDiv
-	sampleMinY := -traceParams.Zero * divRows * traceParams.PerDiv
+	sampleMaxY := (1 - traceParams.Zero) * DivRows * traceParams.PerDiv
+	sampleMinY := -traceParams.Zero * DivRows * traceParams.PerDiv
 	sampleWidthX := float64(len(samples) - 1)
 	sampleWidthY := sampleMaxY - sampleMinY
 

--- a/gui/gui_test.go
+++ b/gui/gui_test.go
@@ -33,7 +33,7 @@ import (
 
 // isOn returns true if pixel x,y is of a different color than white
 func isOn(img image.Image, x, y int) bool {
-	return img.At(x, y) != colorWhite
+	return img.At(x, y) != ColorWhite
 }
 
 // evaluatePlot checks whether the tested plot:
@@ -234,9 +234,9 @@ func TestPlot(t *testing.T) {
 			image.NewRGBA(image.Rect(0, 0, 800, 600)),
 			tc.interp,
 		}
-		testPlot.Fill(colorWhite)
+		testPlot.Fill(ColorWhite)
 		b := testPlot.Bounds()
-		testPlot.DrawSamples(samples, scope.TraceParams{0.5, 0.25}, b, colorBlack)
+		testPlot.DrawSamples(samples, scope.TraceParams{0.5, 0.25}, b, ColorBlack)
 		err = evaluatePlot(refPlot, testPlot, tc.minPointCount)
 		if err != nil {
 			t.Errorf("error in evaluating plot %v against %v: %v", tc.desc, tc.refPlotFile, err)


### PR DESCRIPTION
Overlay plots on top of a constant background image, one reused for each frame.
The background image currently consists only of the rectangular scope grid.

Before:
![screenshot_2017-09-24_12-03-09-before](https://user-images.githubusercontent.com/12544080/30781985-b1faefbe-a129-11e7-98f2-136f134cceab.png)

After:
![screenshot_2017-09-24_12-03-40-after](https://user-images.githubusercontent.com/12544080/30781991-c53917ea-a129-11e7-84e1-35fc7fcfa4fd.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zagrodzki/goscope/43)
<!-- Reviewable:end -->
